### PR TITLE
Fix builds on CentOS

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,8 @@
 resolver: lts-18.26
 allow-newer: true
+flags:
+  cryptonite:
+    support_aesni: false
 packages:
 - '.'
 extra-deps:

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -20,7 +20,7 @@ packages:
     hackage: ruby-marshal-0.2.0
 snapshots:
 - completed:
-    size: 534126
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/16/31.yaml
-    sha256: 637fb77049b25560622a224845b7acfe81a09fdb6a96a3c75997a10b651667f6
-  original: lts-16.31
+    size: 590102
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/18/26.yaml
+    sha256: e76d109964d9335abb412e22139c5bce3078be290ac6d90b8ecea6cc009bb198
+  original: lts-18.26


### PR DESCRIPTION
Cryptonite was previously throwing this error when building on CentOS

```
cryptonite   > [137 of 137] Compiling Crypto.Tutorial
cryptonite   >
cryptonite   > /tmp/stack-677e6576e594a5c1/cryptonite-0.29/In file included from cbits/aes/x86ni.h:38:0: error:
cryptonite   >     0,
cryptonite   >                      from cbits/aes/gf.c:35:
cryptonite   >
cryptonite   > /tmp/stack-677e6576e594a5c1/cryptonite-0.29//usr/lib/gcc/x86_64-redhat-linux/4.8.5/include/wmmintrin.h:34:3: error:
cryptonite   >      error: #error "AES/PCLMUL instructions not enabled"
cryptonite   >      # error "AES/PCLMUL instructions not enabled"
cryptonite   >        ^
cryptonite   >    |
cryptonite   > 34 | # error "AES/PCLMUL instructions not enabled"
cryptonite   >    |   ^
cryptonite   >
cryptonite   > /tmp/stack-677e6576e594a5c1/cryptonite-0.29/In file included from cbits/aes/x86ni.h:39:0: error:
cryptonite   >     0,
cryptonite   >                      from cbits/aes/gf.c:35:
cryptonite   >
cryptonite   > /tmp/stack-677e6576e594a5c1/cryptonite-0.29//usr/lib/gcc/x86_64-redhat-linux/4.8.5/include/tmmintrin.h:31:3: error:
cryptonite   >      error: #error "SSSE3 instruction set not enabled"
cryptonite   >      # error "SSSE3 instruction set not enabled"
cryptonite   >        ^
cryptonite   >    |
cryptonite   > 31 | # error "SSSE3 instruction set not enabled"
cryptonite   >    |   ^
cryptonite   > `gcc' failed in phase `C Compiler'. (Exit code: 1)
```